### PR TITLE
Use system libuuid instead of portable copy

### DIFF
--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,14 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line be updated
+# automatically.
+yum install -y libuuid libuuid-devel
+
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 373c60cf2c5c9eaf598558167aedbc3ef9a0d9b652dfbd96b4725637cf03f628
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win]
 
 requirements:
@@ -20,11 +20,9 @@ requirements:
     - libtool
     - flex
     - bison
-    - libuuid
     - libxml2
     - curl
   run:
-    - libuuid
     - libxml2
     - curl
 

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,2 @@
+libuuid
+libuuid-devel


### PR DESCRIPTION
Ping @ocefpaf -- you mentioned helping out with the `libuuid` issue and I'd love the help here.

Portable copy prevents [Qt from compiling](https://github.com/conda-forge/qt-feedstock/pull/9), but not having `libuuid` in Qt causes linking errors when linux-utils (system) libuuid clashes with portable copy, preventing compiling and running of things like QGIS that combine Qt + GDAL. As far as I can tell, this is 1 of 3 libraries that use `libuuid` and is the only one in the GDAL stack.

For instance, using the new Qt `4.8.7-3` that does not compile with `libuuid-feedstock`, I see:

``` bash
> qgis                           
qgis: /home/ceholden/conda/envs/agdc-py2/bin/../lib/./libuuid.so.1: no version information available (required by /usr/lib/libSM.so.6)
Warning: loading of qgis translation failed [/home/ceholden/conda/envs/agdc-py2/share/qgis/i18n//qgis_en_US]
Warning: loading of qt translation failed [/opt/conda/envs/_build_placehold_placehold_placehold_placehold_placehold_placeho/translations/qt_en_US]
[1]    1768 segmentation fault (core dumped)  qgis
```

This is the same issue I was seeing before `libuuid` was put into the Qt recipe (see [libuuid issue](https://github.com/conda-forge/libuuid-feedstock/issues/8)).

As a first proof of correctness, it looks like either copy -- the "portable" from the `libuuid-feedstock` or the "system" from apt/yum/etc. -- works. The developers use Ubuntu's `uuid-dev` in their testing ([travis.yml](https://github.com/OPENDAP/libdap4/blob/master/.travis.yml#L49)).

Second step -- ensuring this external dependency isn't onerous -- is somewhat harder. As a starting point, the `xenial` Docker image has a copy of the library (`/lib/x86_64-linux-gnu/libuuid.so.1.3.0`). Compiling this build without `libuuid-devel` only seemed to be missing the header files. All of my personal machines and computing cluster machines have this library, and `libuuid-devel` has quite a few reverse dependencies. Not sure how to fully address this but I'd appreciate any feedback or suggestions. 
