### PR TITLE
Change pinning to x.x.x

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -6,8 +6,14 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
-export PYTHONUNBUFFERED=1
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
+
+
+endgroup "Start Docker"
+
+startgroup "Configuring conda"
+export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
@@ -18,8 +24,9 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
+BUILD_CMD=build
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -37,28 +44,37 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
      EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
+endgroup "Configuring conda"
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda debug"
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    startgroup "Running conda $BUILD_CMD"
+    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda build"
+    startgroup "Validating outputs"
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
+    endgroup "Validating outputs"
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+        endgroup "Uploading packages"
     fi
 fi
 

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,29 +1,24 @@
 #!/usr/bin/env bash
 
+source .scripts/logging_utils.sh
+
 set -x
 
-echo -e "\n\nInstalling a fresh version of Miniforge."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:install_miniforge\\r'
-fi
+startgroup "Installing a fresh version of Miniforge"
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:install_miniforge\\r'
-fi
+endgroup "Installing a fresh version of Miniforge"
 
-echo -e "\n\nConfiguring conda."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:configure_conda\\r'
-fi
+startgroup "Configuring conda"
+BUILD_CMD=build
 
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
 
 
 
@@ -39,23 +34,26 @@ echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 
 
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:configure_conda\\r'
-fi
+endgroup "Configuring conda"
 
 set -e
 
-echo -e "\n\nMaking the build clobber file and running the build."
+startgroup "Running conda $BUILD_CMD"
+echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+endgroup "Running conda build"
+startgroup "Validating outputs"
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
+endgroup "Validating outputs"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  echo -e "\n\nUploading the packages."
+  startgroup "Uploading packages"
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  endgroup "Uploading packages"
 fi

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About libdap4
 
 Home: http://www.opendap.org
 
-Package license: GNU LGPL
+Package license: GPL-2.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libdap4-feedstock/blob/master/LICENSE.txt)
 
@@ -167,9 +167,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
 
 about:
   home: http://www.opendap.org
-  license: GNU LGPL
+  license: GPL-2.0-or-later
   license_file: COPYING
   summary: A C++ SDK which contains an implementation of both DAP2 and DAP4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,12 @@ source:
   sha256: e44e83043c158d8c9d0a37a1821626ab0db4a1a6578b02182440170c0b060e6d
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
-    # no ABI lab entry.  Going with minor pinning based on past conda-forge pinning.
-    - {{ pin_subpackage('libdap4', max_pin='x.x') }}
+    # Seems to break ABI on some point releases
+    # see https://abi-laboratory.pro/?view=timeline&l=libdap
+    - {{ pin_subpackage('libdap4', max_pin='x.x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This will match the global pinning (https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/d53275df5bd06ab6f07f736c04ed1a72ebb9b93f/recipe/conda_build_config.yaml#L460).

Seems upstream do occasionally make breaking ABI changes on point releases (https://abi-laboratory.pro/?view=timeline&l=libdap). 

Helps with https://github.com/conda-forge/gdal-feedstock/pull/466 where we are unable to get the latest versions of `libdap4` on aarch64 etc because the pinning hasn't been updated.